### PR TITLE
fix: correct field container tag in Case layout summary

### DIFF
--- a/force-app/main/default/layouts/Case-Case %28Marketing%29 Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Case-Case %28Marketing%29 Layout.layout-meta.xml
@@ -291,56 +291,56 @@
         <masterLabel>00h1a0000012AHE</masterLabel>
         <sizeX>3</sizeX>
         <sizeY>4</sizeY>
-        <summaryLayoutItems>
+        <summaryLayoutItem>
             <field>ContactId</field>
             <posX>0</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>AccountId</field>
             <posX>0</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>ContactPhone</field>
             <posX>0</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CaseNumber</field>
             <posX>1</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CreatedDate</field>
             <posX>1</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Subject</field>
             <posX>1</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Description</field>
             <posX>1</posX>
             <posY>3</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Status</field>
             <posX>2</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Priority</field>
             <posX>2</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>OwnerId</field>
             <posX>2</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
+        </summaryLayoutItem>
         <summaryLayoutStyle>CaseInteraction</summaryLayoutStyle>
     </summaryLayout>
 </Layout>

--- a/force-app/main/default/layouts/Case-Case %28Sales%29 Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Case-Case %28Sales%29 Layout.layout-meta.xml
@@ -291,56 +291,56 @@
         <masterLabel>00h1a0000012AH9</masterLabel>
         <sizeX>3</sizeX>
         <sizeY>4</sizeY>
-        <summaryLayoutItems>
+        <summaryLayoutItem>
             <field>ContactId</field>
             <posX>0</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>AccountId</field>
             <posX>0</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>ContactPhone</field>
             <posX>0</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CaseNumber</field>
             <posX>1</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CreatedDate</field>
             <posX>1</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Subject</field>
             <posX>1</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Description</field>
             <posX>1</posX>
             <posY>3</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Status</field>
             <posX>2</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Priority</field>
             <posX>2</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>OwnerId</field>
             <posX>2</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
+        </summaryLayoutItem>
         <summaryLayoutStyle>CaseInteraction</summaryLayoutStyle>
     </summaryLayout>
 </Layout>

--- a/force-app/main/default/layouts/Case-Case %28Support%29 Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Case-Case %28Support%29 Layout.layout-meta.xml
@@ -301,56 +301,56 @@
         <masterLabel>00h1a0000012AHJ</masterLabel>
         <sizeX>3</sizeX>
         <sizeY>4</sizeY>
-        <summaryLayoutItems>
+        <summaryLayoutItem>
             <field>ContactId</field>
             <posX>0</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>AccountId</field>
             <posX>0</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>ContactPhone</field>
             <posX>0</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CaseNumber</field>
             <posX>1</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CreatedDate</field>
             <posX>1</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Subject</field>
             <posX>1</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Description</field>
             <posX>1</posX>
             <posY>3</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Status</field>
             <posX>2</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Priority</field>
             <posX>2</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>OwnerId</field>
             <posX>2</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
+        </summaryLayoutItem>
         <summaryLayoutStyle>CaseInteraction</summaryLayoutStyle>
     </summaryLayout>
 </Layout>

--- a/force-app/main/default/layouts/Case-Case Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Case-Case Layout.layout-meta.xml
@@ -301,56 +301,56 @@
         <masterLabel>00h1a0000012AGt</masterLabel>
         <sizeX>3</sizeX>
         <sizeY>4</sizeY>
-        <summaryLayoutItems>
+        <summaryLayoutItem>
             <field>ContactId</field>
             <posX>0</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>AccountId</field>
             <posX>0</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>ContactPhone</field>
             <posX>0</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CaseNumber</field>
             <posX>1</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>CreatedDate</field>
             <posX>1</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Subject</field>
             <posX>1</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Description</field>
             <posX>1</posX>
             <posY>3</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Status</field>
             <posX>2</posX>
             <posY>0</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>Priority</field>
             <posX>2</posX>
             <posY>1</posY>
-        </summaryLayoutItems>
-        <summaryLayoutItems>
+        </summaryLayoutItem>
+        <summaryLayoutItem>
             <field>OwnerId</field>
             <posX>2</posX>
             <posY>2</posY>
-        </summaryLayoutItems>
+        </summaryLayoutItem>
         <summaryLayoutStyle>CaseInteraction</summaryLayoutStyle>
     </summaryLayout>
 </Layout>


### PR DESCRIPTION
## Summary
- fix improper <field> tag placement in Case summary layouts by replacing summaryLayoutItems with summaryLayoutItem

## Testing
- `npm test`
- `npm run prettier:verify`

------
https://chatgpt.com/codex/tasks/task_e_6892ecaf9c1c8322b5eee2b3145539b8