### PR TITLE
chore: ignore standard object metadata

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -10,3 +10,7 @@ package.xml
 
 # LWC Jest
 **/__tests__/**
+# Ignore all standard object metadata except custom SelfKnowlege__c
+force-app/main/default/objects/*
+!force-app/main/default/objects/SelfKnowlege__c
+!force-app/main/default/objects/SelfKnowlege__c/**

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ $RECYCLE.BIN/
 **/__pycache__/
 **/.venv/
 **/venv/
+
+# Ignore package-lock to prevent accidental commits
+package-lock.json


### PR DESCRIPTION
## Summary
- prevent accidental deployment of standard object metadata by ignoring all standard objects except `SelfKnowlege__c`
- ignore `package-lock.json`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68959f122fec8322bd694c864512b465